### PR TITLE
Adds Jiffy as a dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,9 @@ deps
 erl_crash.dump
 .concrete/DEV_MODE
 .rebar
+rebar3
+_build/
+rebar.lock
+*.DS_Store
 *.*#
+compile_commands.json

--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,7 @@
 {erl_opts, [debug_info, {parse_transform, lager_transform}]}.
 {deps, [
-         {hashids, ".*",  {git, "https://github.com/snaiper80/hashids-erlang.git",  {tag, "1.0.4"}}},
-	 {lager, "1.2.1", {git, "https://github.com/basho/lager.git", {tag, "1.2.1"}}}
-       ]
+    {hashids, ".*",  {git, "https://github.com/snaiper80/hashids-erlang.git",  {tag, "1.0.4"}}},
+    {lager, "1.2.1", {git, "https://github.com/basho/lager.git", {tag, "1.2.1"}}},
+    {jiffy, ".*", {git, "https://github.com/davisp/jiffy.git", {branch, "feature-add-rebar3-support"}}}
+    ]
 }.

--- a/src/adb_server.erl
+++ b/src/adb_server.erl
@@ -28,7 +28,7 @@
 	, terminate/2
 	, code_change/3]).
 
--export([split_command/1]).
+-export([split/1]).
 
 -define(SERVER, ?MODULE).      % declares a SERVER macro constant (?MODULE is the module's name) 
 


### PR DESCRIPTION
1. Adds the Jiffy as a rebar dependency.
   `{jiffy, ".*", {git, "https://github.com/davisp/jiffy.git", {branch, "feature-add-rebar3-support"}}}`
2. Build the project using rebar3 compile.
3. After error message when compiling, edit in the following file core/_build/default/lib/jiffy/rebar.config.script

This line:
`PortCompilerUrl = "git@github.com:blt/port_compiler.git",`

To this line:
`PortCompilerUrl = "https://github.com/blt/port_compiler.git",`
