### PR TITLE
Issue7 adding hanoidb

### DIFF
--- a/ebin/adb_core.app
+++ b/ebin/adb_core.app
@@ -6,7 +6,7 @@
  {applications, [kernel, stdlib, lager]},
  {mod, {adb_app, 
         % {persistence, ets | hanoidb}
-        [{persistence, ets}]
+        [{persistence, hanoidb}]
        }
  }
 ]}.

--- a/src/adb_sup.erl
+++ b/src/adb_sup.erl
@@ -23,14 +23,14 @@ start_link(LSock) ->
     start_link(LSock, []).
 
 start_link(LSock, Args) ->
-    setup_persistence(Args),
-    supervisor:start_link({local, ?SERVER}, ?MODULE, [LSock]).
+    Persistence = setup_persistence(Args),
+    supervisor:start_link({local, ?SERVER}, ?MODULE, [LSock, Persistence]).
 
 start_child() ->
     supervisor:start_child(?SERVER, []).
 
-init([LSock]) ->
-    Server = {adb_server, {adb_server, start_link, [LSock]}, % {Id, Start, Restart, ... }  
+init([LSock, Persistence]) ->
+    Server = {adb_server, {adb_server, start_link, [LSock, Persistence]}, % {Id, Start, Restart, ... }
 	      temporary, brutal_kill, worker, [adb_server]},
     Children = [Server], 
     RestartStrategy = {simple_one_for_one, 0, 1},  % {How, Max, Within} ... Max restarts within a period

--- a/src/adb_sup.erl
+++ b/src/adb_sup.erl
@@ -39,10 +39,9 @@ init([LSock, Persistence]) ->
 setup_persistence(Args) ->
     lager:info("Setting up the persistence module.", []),
     case proplists:get_value(persistence, Args) of
-      hanoidb -> lager:info("HanoiDB still not supported. Please verify your
-                            persistence configuration."),
-                 throw(invalid_persistence);
-      ets     -> lager:info("Starting ets"),
+      hanoidb -> lager:info("Starting HanoiDB..."),
+                 hanoidb_persistence;
+      ets     -> lager:info("Starting ets..."),
                  _Docs = ets:new(docs, [set, public, named_table]),
                  ets_persistence
     end.

--- a/src/hanoidb_persistence.erl
+++ b/src/hanoidb_persistence.erl
@@ -1,0 +1,62 @@
+-module(hanoidb_persistence).
+
+-export([save/0, lookup/0, update/0, delete/0]).
+
+save() ->
+  receive
+    {_From, Doc} -> B_Doc = list_to_binary(Doc),
+                    _From ! {save, save(B_Doc)}
+  end.
+
+lookup() ->
+  receive
+    {_From, Key} -> B_Key = list_to_binary(Key),
+                    _From ! {lookup, lookup(B_Key)}
+  end.
+
+delete() ->
+  receive
+    {_From, Key} -> B_Key = list_to_binary(Key),
+                    _From ! {delete, delete(B_Key)}
+  end.
+
+update() ->
+  receive
+    {_From, {Key, Doc}} -> B_Key = list_to_binary(Key),
+                           B_Doc = list_to_binary(Doc),
+                           _From ! {update, update(B_Key, B_Doc)}
+  end.
+
+save(Value) ->
+    Key = gen_id(),
+    save(list_to_binary(Key), Value).
+save(Key, Value) ->
+    {ok, Tree} = hanoidb:open_link("adb"),
+    hanoidb:put(Tree, Key, Value),
+    hanoidb:close(Tree),
+    Key.
+
+lookup(Key) ->
+    {ok, Tree} = hanoidb:open_link("adb"),
+    Result = hanoidb:get(Tree, Key),
+    hanoidb:close(Tree),
+    Result.
+
+delete(Key) ->
+    {ok, Tree} = hanoidb:open_link("adb"),
+    Result = hanoidb:delete(Tree, Key),
+    hanoidb:close(Tree),
+    Result.
+
+update(Key, Value) ->
+    delete(Key),
+    save(Key,Value).
+
+gen_id() ->
+    Time=erlang:system_time(nano_seconds),
+    StringTime=integer_to_list(Time),
+    UniformRandom=rand:uniform(10000),
+    StringRandom=integer_to_list(UniformRandom),
+    {Id, _} = string:to_integer(StringRandom++StringTime),
+    Ctx = hashids:new([{salt, "AngraDB"}, {min_hash_length, 1}, {default_alphabet, "ABCDEF0123456789"}]),
+    hashids:encode(Ctx, Id).


### PR DESCRIPTION
Pull request for issue #7 . 
IMPORTANT: the `ebloom` dependency might not be compiled correcly even after `rebar3 compile`, so you will have to manually compile it. Just `cd` into the directory dependency (usually "_build/default/lib/ebloom/" and execute a `./rebar compile` so it will compile properly.

IMPORTANT_2: the hanoidb needs to be started with the app.config loaded. But it's not intuitive to do with rebar. See [this issue](https://github.com/erlang/rebar3/issues/1172). So, to start the application for hanoidb use, you might want to do `ERL_FLAGS="-config app.config" rebar3 shell` so it will load the config file properly.
