### PR TITLE
Issue15

### DIFF
--- a/ebin/adb_core.app
+++ b/ebin/adb_core.app
@@ -6,7 +6,7 @@
  {applications, [kernel, stdlib, lager]},
  {mod, {adb_app, 
         % {persistence, ets | hanoidb}
-        [{persistence, hanoidb}]
+        [{persistence, ets}]
        }
  }
 ]}.

--- a/src/ets_persistence.erl
+++ b/src/ets_persistence.erl
@@ -15,8 +15,8 @@ teardown(_) ->
 
 createDB(DB) ->
     DBName = list_to_atom(DB),
-    NDB = ets:new(DBName, [set, public, named_table]),
-    {ok, NDB}.
+    _NDB = ets:new(DBName, [set, public, named_table]),
+    {ok}.
 
 connect(DB) ->
     DBName = list_to_atom(DB),

--- a/src/hanoidb_persistence.erl
+++ b/src/hanoidb_persistence.erl
@@ -2,11 +2,17 @@
 
 -behaviour(gen_persistence).
 
--export([setup/1, teardown/1, save/3, lookup/2, update/3, delete/2]).
+-export([setup/1, teardown/1, createDB/1, connect/1, save/3, lookup/2, update/3, delete/2]).
 
 setup([DBName]) ->
     {ok, Tree} = hanoidb:open_link(DBName),
     Tree.
+
+connect(DB) ->
+    ok. 
+
+createDB(DB) ->
+    ok. 
 
 teardown(Tree) ->
     hanoidb:close(Tree).


### PR DESCRIPTION
The gen_persistence does not spawn a new process for each database command. We have to think about this, in particular because the functions start and teardown look less necessary.... at least to the ETS implementation. We also have to reason about the impact of those changes with respect to the HanoiDB and B+Tree implementation. 
