### PR TITLE
First version of btree index compression, it is now working.

### DIFF
--- a/src/adbtree.hrl
+++ b/src/adbtree.hrl
@@ -1,7 +1,7 @@
 -define(SizeOfPointer, 8).
 -define(SizeOfHeader, 66).
 -define(OrderSize, 2).
--define(KeySize, 12).
+-define(KeySize, 14).
 -define(Node, 0).
 -define(Leaf, 1).
 -define(SizeOfSize, 8).
@@ -10,7 +10,6 @@
 -define(DefaultMaxSize, 16).
 
 -record(dbsettings, {dbname, sizeinbytes, sizeversion}).
-
 -record(btree, {order, curNode}).
 -record(node, {keys, nodePointers}).
 -record(leaf, {keys, docPointers, leafPointer, versions}).

--- a/src/adbtree_persistence.erl
+++ b/src/adbtree_persistence.erl
@@ -23,8 +23,8 @@ teardown(Tree) ->
     adbtree:close(Tree).
 
 save(Tree, Key, Value) ->
-    adbtree:save(atom_to_list(Tree), list_to_binary(Value), list_to_integer(Key, 16)),
-    Key.
+    {ok, NewKey} = adbtree:save(atom_to_list(Tree), list_to_binary(Value), list_to_integer(Key, 16)),
+    integer_to_list(NewKey, 16).
 
 lookup(Tree, Key) ->
   try


### PR DESCRIPTION
The first version works as expected. A index file with the previous index is created. The size of the key was changed, so the previously created index should not be used.